### PR TITLE
Override trusted_proxy? in the module where it is originally defined.

### DIFF
--- a/lib/rack-custom-proxies.rb
+++ b/lib/rack-custom-proxies.rb
@@ -8,18 +8,19 @@ module RackCustomProxies
     end
   end
 
+  def self.included(base)
+    base.extend ClassMethods
+  end
+end
+
+require 'rack/request'
+Rack::Request.send :include, RackCustomProxies
+
+module Rack::Request::Helpers
   def trusted_proxy?(ip)
     Rack::Request.trusted_proxies.each do |tp|
       return true if tp.include?(ip)
     end
     false
   end
-
-  def self.included(base)
-    base.extend ClassMethods
-  end
-
 end
-
-require 'rack/request'
-Rack::Request.send :include, RackCustomProxies


### PR DESCRIPTION
Classes other than Rack::Request also include Rack::Request::Helpers (such as ActionDispatch::Request), so overriding it  in Rack::Request means it only takes effect for Rack apps.